### PR TITLE
Add conditional Categorical distribution

### DIFF
--- a/src/ConditionalDists.jl
+++ b/src/ConditionalDists.jl
@@ -12,12 +12,14 @@ export condition
 
 export ConditionalDistribution
 export ConditionalMvNormal
+export ConditionalCategorical
 export SplitLayer
 
 include("cond_dist.jl")
 
 include("batch_mvnormal.jl")
 include("cond_mvnormal.jl")
+include("categorical.jl")
 include("utils.jl")
 
 function __init__()

--- a/src/categorical.jl
+++ b/src/categorical.jl
@@ -1,0 +1,76 @@
+#import Distributions: probs
+#import ConditionalDists: condition
+
+"""
+    ConditionalCategorical(m)
+
+Specialization of ConditionalDistribution for `Categorical`. Can be used for
+single inputs as well as batches. If the input is a batch, returns `BatchCategorical`.
+Allows for a parametrized, differentiable categorical distribution.
+
+**Important!** The mapping needs to return a probability distribution.
+Easiest way to ensure this is to use softmax after the neural network
+layers.
+
+# Code example
+
+```julia-repl
+julia> m = Chain(Dense(2, 4, swish), Dense(4, 2), softmax)
+julia> p = ConditionalCategorical(m)
+julia> condition(p, randn(2))
+julia> condition(p, randn(2, 5))
+```
+"""
+struct ConditionalCategorical{Tm} <: AbstractConditionalDistribution
+    mapping::Tm
+end
+
+Distributions.probs(p::ConditionalCategorical, z::AbstractVector) = probs(condition(p, z))
+
+function condition(p::ConditionalCategorical, z::AbstractVector)
+    α = p.mapping(z)
+    DistributionsAD.Categorical(α)
+end
+
+function condition(p::ConditionalCategorical, z::AbstractMatrix)
+    α = p.mapping(z)
+    BatchCategorical(α)
+end
+
+# Flux.@functor ConditionalCategorical
+@functor ConditionalCategorical
+
+"""
+    BatchCategorical
+
+Implements a Categorical distribution for batches of samples, where the batch
+is a matrix of size (n_classes, n_samples).
+"""
+struct BatchCategorical{Tm <: AbstractMatrix} <: DiscreteMatrixDistribution
+    α::Tm
+end
+
+Distributions.probs(p::BatchCategorical) = p.α
+Base.eltype(p::BatchCategorical) = eltype(p.α)
+Distributions.params(p::BatchCategorical) = (p.α,)
+
+function Distributions.pdf(p::BatchCategorical, y::AbstractVector{T}) where T <: Real
+    α = probs(p)
+    n = size(α, 2)
+    xr = round.(Int, y)
+    map(i -> α[xr[i], i], 1:n)
+end
+function Distributions.logpdf(p::BatchCategorical, y::AbstractVector{T}) where T <: Real
+    log.(pdf(p, y))
+end
+
+# we do not need this to be differentiable (no reparametrization trick)
+function Distributions.rand(p::BatchCategorical)
+    α = probs(p)
+    map(x -> rand(Categorical(collect(x))), eachcol(α))
+end
+
+function Distributions.entropy(p::BatchCategorical)
+    α = probs(p)
+    map(i -> entropy(α[:, i]), 1:size(α, 2))
+end

--- a/test/categorical.jl
+++ b/test/categorical.jl
@@ -1,0 +1,49 @@
+@testset "ConditionalCategorical" begin
+    c = 3
+    x = randn(2)
+    y = 1
+    xb = randn(2, 5)
+    yb = [1,2,3,2,3]
+    
+    m = Chain(Dense(2, 3, swish), Dense(3,c), softmax)
+    p = ConditionalCategorical(m)
+
+    # test that the distribution is differentiable
+    # and parameters are okay
+    ps = Flux.params(p)
+    @test !isempty(ps)
+    @test length(ps) == length(Flux.params(m))
+    fl() = logpdf(condition(p, x), y)
+    @test_nowarn Flux.gradient(fl, ps)
+
+    # test for vectors
+    res = condition(p, x)
+    @test res isa Categorical
+    @test size(probs(res)) == (c, )
+
+    # test for batches
+    res = condition(p, xb)
+    @test res isa ConditionalDists.BatchCategorical
+    @test size(probs(res)) == (c, size(xb, 2))
+
+    # test pdf, logpdf and entropy for single
+    f(x) = [0.2,0.3,0.5]
+    p = ConditionalCategorical(f)
+    res = condition(p, x)
+
+    @test entropy(res) == entropy([0.2,0.3,0.5])
+    @test pdf.(res, [1,2,3]) == [0.2,0.3,0.5]
+    @test logpdf.(res, [1,2,3]) == log.([0.2,0.3,0.5])
+
+    # test pdf, logpdf, entropy for batch
+    g(x) = mapreduce(xi -> f(xi), hcat, eachcol(x))
+    p = ConditionalCategorical(g)
+    res = condition(p, xb)
+
+    @test length(unique(entropy(res))) == 1
+    @test unique(entropy(res))[1] == entropy([0.2,0.3,0.5])
+    @test length(pdf(res, yb)) == size(xb, 2)
+    @test pdf(res, yb) == [0.2,0.3,0.5,0.3,0.5]
+    @test logpdf(res, yb) == log.([0.2,0.3,0.5,0.3,0.5])
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using ConditionalDists: BatchMvNormal, SplitLayer
 
 include("cond_dist.jl")
 include("cond_mvnormal.jl")
+include("categorical.jl")
 include("utils.jl")
 
 # for the BatchMvNormal tests to work BatchMvNormals have to be functors!


### PR DESCRIPTION
Add ConditionalCategorical, both batch and vector version, to ConditionalDists.jl. Some tests have been made and are passing. There is still a bit of work that should be done if this is to be merged to the original repository.

Note: First, we need to decide if we want to stay connected to DistributionsAD.jl, which it currently is.

Note 2: This version works with the newest version of Flux (12.9), DistributionsAD (0.6.38).